### PR TITLE
feat(setuptools): Add setup.py to implement setuptools

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,16 @@
+# Manifest syntax https://docs.python.org/2/distutils/sourcedist.html
+graft wheelhouse
+
+recursive-exclude __pycache__  *.pyc *.pyo *.orig
+
+exclude *.git*
+exclude *.sh
+exclude *imtihaan.py
+
+include requirements*.*
+include *.py
+
+prune .git
+prune venv
+prune test*
+

--- a/README.md
+++ b/README.md
@@ -5,33 +5,75 @@ New License Scanner Project Which Should be Integrated with FOSSology but also W
 - Python v3.x
 - pip
 
-### Steps for Installation
+## Steps for Installation
+### Build (optional)
+- `$ python setup.py build`
+- Build will generate 3 new files in your current directory
+    1.  `data/Ngram_keywords.json`
+    2.  `licenses/<SPDX-version>.csv`
+    3.  `licenses/processedList.csv`
+- These files will be placed to their appropriate places by the install script.
+### Install
+- `# python setup.py install`
 - In install folder, make the "atarashi-install.sh" executable
 - Run <./atarashi-install.sh>
 - pip install -r <pathto/requirements.txt>
 
 
-## Downloading license list from SPDX
-- Run `python license_extractor/LicenseDownloader.py`
-- The script will create a file under licenses folder and return the path on CLI.
-- This file can be used with other modules.
-- To update list, simply run the same command.
+## How to run
+Get the help by running `atarashi -h` or `atarashi --help`
+### Example
+- Running **DLD** agent
 
-### Preprocessing License List
-- In scripts folder, run `python LicensePreprocessor.py <path_to_licenselist.csv> <dest_to_new_list.csv>`.
-- The code will return the path to preprocessed license list.
-- Use this list while running modules.
+    `atarashi -a DLD /path/to/file.c`
+- Running **wordFrequencySimilarity** agent
 
+    `atarashi -a wordFrequencySimilarity /path/to/file.c`
+- Running **tfidf** agent
+    - With **Cosine similarity**
 
-### How to run
-- You can check how to run any module ( CommentExtractor, CommentPreprocessor,
-dameruLevenDist, getLicenses, LicensePreprocessor, pariksha, tfidf, wordFrequencySimilarity )
-using `-h` or `--help` command.
-- For verbose mode use `-v` or `--verbose` flag with file name
-- eg. `python tfidf.py <inputFile> <licenseList> -v`
-- For using stop word filtering, use `-s` or `--stop-words`
+        `atarashi -a tfidf /path/to/file.c`
+
+        `atarashi -a tfidf -s CosineSim /path/to/file.c`
+    - With **Score similarity**
+
+        `atarashi -a tfidf -s ScoreSim /path/to/file.c`
+- Running **Ngram** agent
+    - With **Cosine similarity**
+
+        `atarashi -a Ngram /path/to/file.c`
+
+        `atarashi -a Ngram -s CosineSim /path/to/file.c`
+    - With **Dice similarity**
+
+        `atarashi -a Ngram -s DiceSim /path/to/file.c`
+    - With **Bigram Cosine similarity**
+
+        `atarashi -a Ngram -s BigramCosineSim /path/to/file.c`
+- Running in **verbose** mode
+
+    `atarashi -a DLD -v /path/to/file.c`
+- Running with custom CSVs and JSONs
+    - Please reffer to the build instructions to get the CSV and JSON
+    understandable by atarashi.
+    - `atarashi -a DLD -l /path/to/processedList.csv /path/to/file.c`
+    - `atarashi -a Ngram -l /path/to/processedList.csv -j /path/to/ngram.json /path/to/file.c`
+
 
 ### Test
-- Run pariksha (meaning *Test* in Hindi) with the name of the Agent.
-- eg. `python pariksha.py tfidfcosinesim <licenseList>`
+- Run imtihaan (meaning *Exam* in Hindi) with the name of the Agent.
+- eg. `python atarashi/imtihaan.py /path/to/processedList.csv <DLD|tfidf|Ngram> <testfile>`
+- See `python atarashi/imtihaan.py --help` for more
+
+## Creating Debian packages
+- Install dependencies
+```
+# apt-get install python3-setuptools python3-all debhelper
+# pip install stdeb
+```
+- Create Debian packages
+```
+$ python3 setup.py --command-packages=stdeb.command bdist_deb
+```
+- Locate the files under `deb_dist`
 

--- a/atarashi/build_deps.py
+++ b/atarashi/build_deps.py
@@ -1,0 +1,67 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""
+Copyright 2018 Gaurav Mishra <gmishx@gmail.com>
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+version 2 as published by the Free Software Foundation.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+
+__author__ = "Gaurav Mishra"
+__email__ = "gmishx@gmail.com"
+
+import argparse
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)) + '/../')
+
+from atarashi.libs.ngram import createNgrams
+from atarashi.license.licenseDownloader import LicenseDownloader
+from atarashi.license.licensePreprocessor import LicensePreprocessor
+from atarashi.license.license_merger import license_merger
+
+
+"""
+Creates required files for Atarashi.
+
+First downloads SPDX licenses, then merge them with FOSSology licenses.
+The merged CSV is then processesed which is then used to create the Ngrams.
+"""
+
+if __name__ == "__main__":
+  parser = argparse.ArgumentParser()
+  parser.add_argument("-t", "--threads", required = False, default = os.cpu_count(),
+                      type = int,
+                      help = "No of threads to use for download. Default: CPU count")
+  parser.add_argument("-v", "--verbose", help = "increase output verbosity",
+                      action = "count", default = 0)
+  args = parser.parse_args()
+  threads = args.threads
+  verbose = args.verbose
+
+  currentDir = os.path.dirname(os.path.abspath(__file__))
+  licenseListCsv = currentDir + "/../licenses/licenseList.csv"
+  processedLicenseListCsv = currentDir + "/../licenses/processedLicenses.csv"
+  ngramJsonLoc = currentDir + "/../data/Ngram_keywords.json"
+
+  print("** Downloading SPDX licenses **")
+  spdxLicenseList = LicenseDownloader.download_license(threads)
+  print("** Merging SPDX and FOSSology licenses **")
+  spdxLicenseList = license_merger(licenseListCsv, spdxLicenseList)
+  print("** Processing licenses **")
+  processedLicenseListCsv = LicensePreprocessor.create_processed_file(
+    spdxLicenseList,
+    processedLicenseListCsv,
+    verbose = verbose)
+  print("** Generating Ngrams **")
+  createNgrams(processedLicenseListCsv, ngramJsonLoc, threads, verbose)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ scikit-learn>=0.18.1
 scipy>=0.18.1
 textdistance>=3.0.3
 setuptools>=39.2.0
+git+https://github.com/amanjain97/code_comment.git#egg=code_comment-master

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,135 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""
+Copyright 2018 Gaurav Mishra <gmishx@gmail.com>
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+version 2 as published by the Free Software Foundation.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+import distutils.cmd
+import os
+from setuptools import setup, find_packages
+import setuptools.command.build_py
+import subprocess
+
+__author__ = "Gaurav Mishra"
+__email__ = "gmishx@gmail.com"
+
+
+# Utility function to read the README file.
+# Used for the long_description.  It's nice, because now 1) we have a top level
+# README file and 2) it's easier to type in the README file than to put a raw
+# string in below ...
+def read(fname):
+  """
+  Utility function to read the README file.
+  :param fname: Path to file to read
+  :rtype: String
+  Returns file content
+  """
+  return open(os.path.join(os.path.dirname(__file__), fname)).read()
+
+
+class BuildAtarashiDependencies(distutils.cmd.Command):
+  """
+  Class to build dependency files for Atarashi.
+  Files created:
+  1.  data/Ngram_keywords.json
+  2.  licenses/<spdx_license>.csv
+  3.  licenses/processedLicenses.csv
+  """
+  description = 'build Atarashi dependency files'
+  user_options = [
+      ('threads=', 't', 'Number of threads to use')
+  ]
+
+  def initialize_options(self):
+    """Set default values for options."""
+    self.threads = os.cpu_count()
+
+  def finalize_options(self):
+    """Check the values for options."""
+    if self.threads:
+      self.threads = int(self.threads)
+      assert self.threads > 0
+
+  def run(self):
+    """Run atarashi/build_deps.py"""
+    subprocess.run([
+        "atarashi/build_deps.py",
+        "-t", str(self.threads),
+      ], check = True)
+
+
+class BuildAtarashi(setuptools.command.build_py.build_py):
+  """
+  Class to replace default `build_py` and call `build_deps`.
+  """
+  def run(self):
+    """Run `build_deps` target."""
+    self.run_command('build_deps')
+    setuptools.command.build_py.build_py.run(self)
+
+
+requirements = [
+  'tqdm>=4.23.4',
+  'pandas>=0.23.1',
+  'pyxDamerauLevenshtein>=1.5',
+  'scikit-learn>=0.18.1',
+  'scipy>=0.18.1',
+  'textdistance>=3.0.3',
+  'setuptools>=39.2.0']
+
+setup(
+  name = "atarashi",
+  version = "0.0.9",
+  author = "Aman Jain",
+  author_email = "amanjain5221@gmail.com",
+  description = ("An intelligent license scanner."),
+  license = "GPL-2.0-only",
+  url = "https://github.com/siemens/atarashi",
+  long_description = read('README.md'),
+  classifiers = [
+    "Development Status ::  Pre-Alpha",
+    "Topic :: Utilities",
+    "License :: OSI Approved :: GPL v2.0 License",
+  ],
+  keywords = [
+    "atarashi", "license", "license-scanner", "oss",
+    "oss-compliance"
+  ],
+  python_requires = ">=3.5",
+  packages = find_packages(),
+  entry_points = {
+    'console_scripts': [
+      'atarashi = atarashi.atarashii:main'
+    ]
+  },
+  zip_safe = False,
+  setup_requires = requirements,
+  install_requires = requirements,
+  dependency_links = ['git+https://github.com/amanjain97/code_comment#egg=code_comment'],
+  package_data = {
+    'data': ['data/Ngram_keywords.json'],
+    'licenses': ['licenses/licenseList.csv', 'licenses/processedLicenses.csv']
+  },
+  data_files = [
+    ('data', ['data/Ngram_keywords.json']),
+    ('licenses', ['licenses/licenseList.csv', 'licenses/processedLicenses.csv'])
+  ],
+  cmdclass = {
+    'build_deps': BuildAtarashiDependencies,
+    'build_py': BuildAtarashi,
+  },
+)
+


### PR DESCRIPTION
Added `setup.py` to implement `setuptools`.

To install atarashi, simply run
`# python3 setup.py install`

It will create a executable named `atarashi` in system PATH

Please refer to README.md for more.