### PR TITLE
docs(Sphinx): How to add sphinx documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,3 +117,24 @@ See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software Foundation,
 Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+## How to generate the documentation using sphinx
+
+1. Go to project directory 'atarashi'
+2. export PYTHONPATH=$PYTHONPATH:${PWD}
+    - PYTHONPATH sets the search path for the importing python module.
+3. Install Sphinx `pip install sphinx` (Since this project is based on python so `pip` is already installed)
+4. In the project directory, `sphinx-quickstart`
+    - `Root path for the documentation [.]: docs`
+    - `Separate source and build directories (y/n) [n]: y`
+    - `autodoc: automatically insert docstrings from modules (y/n) [n]: y`
+    -  Else use the default option
+5. Auto-generate the .rst files in docs/source which will be used to generate documentation 
+    - `sphinx-autodoc -o docs/source atarashi/`
+6. `cd docs`
+7. `make html`
+
+This will generate file in docs/build/html. Go to: index.html
+
+You can change the theme of the documentation by changing the config.py file in docs/source folder. You can choose from {'alabaster', 'classic', 'sphinxdoc', 'scrolls', 'agogo', 'traditional', 'nature', 'haiku', 'pyramid', 'bizstyle'} 
+[Reference](http://www.sphinx-doc.org/en/master/theming.html)  

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ http://fossology.github.io/atarashi
 
 ### Requirements
 
-- Python v3.x
+- Python >= v3.5
 - pip
 
 ## Steps for Installation
@@ -120,21 +120,59 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 ## How to generate the documentation using sphinx
 
-1. Go to project directory 'atarashi'
-2. export PYTHONPATH=$PYTHONPATH:${PWD}
-    - PYTHONPATH sets the search path for the importing python module.
-3. Install Sphinx `pip install sphinx` (Since this project is based on python so `pip` is already installed)
-4. In the project directory, `sphinx-quickstart`
-    - `Root path for the documentation [.]: docs`
-    - `Separate source and build directories (y/n) [n]: y`
-    - `autodoc: automatically insert docstrings from modules (y/n) [n]: y`
-    -  Else use the default option
-5. Auto-generate the .rst files in docs/source which will be used to generate documentation 
-    - `sphinx-autodoc -o docs/source atarashi/`
+1. Go to project directory 'atarashi'.
+2. Install Sphinx and m2r `pip install sphinx m2r` (Since this project is based on python so `pip` is already installed).
+3. Initialise `docs/` directory with `sphinx-quickstart`
+
+    ```bash
+    mkdir docs
+    cd docs/
+    sphinx-quickstart
+    ```
+   - `Root path for the documentation [.]: .`
+   - `Separate source and build directories (y/n) [n]: n`
+   - `autodoc: automatically insert docstrings from modules (y/n) [n]: y`
+   - `intersphinx: link between Sphinx documentation of different projects (y/n) [n]: y`
+   - Else use the default option
+4. Setup the `conf.py` and include `README.md`
+   - Enable the following lines and change the insert path:
+
+        ```python
+        import os
+        import sys
+        sys.path.insert(0, os.path.abspath('../'))
+        ```
+   - Enable `m2r` to insert `.md` files in Sphinx documentation:
+
+        ```python
+        [...]
+        extensions = [
+          ...
+          'm2r',
+        ]
+        [...]
+        source_suffix = ['.rst', '.md']
+        ```
+   - Include `README.md` by editing `index.rst`
+
+        ```rst
+        .. toctree::
+            [...]
+            readme
+
+        .. mdinclude:: ../README.md
+        ```
+5. Auto-generate the `.rst` files in `docs/source` which will be used to generate documentation
+
+    ```bash
+    cd docs/
+    sphinx-apidoc -o source/ ../atarashi
+    ```
 6. `cd docs`
 7. `make html`
 
-This will generate file in docs/build/html. Go to: index.html
+This will generate file in `docs/_build/html`. Go to: index.html
 
-You can change the theme of the documentation by changing the config.py file in docs/source folder. You can choose from {'alabaster', 'classic', 'sphinxdoc', 'scrolls', 'agogo', 'traditional', 'nature', 'haiku', 'pyramid', 'bizstyle'} 
+You can change the theme of the documentation by changing `html_theme` in config.py file in `docs/` folder. 
+You can choose from {'alabaster', 'classic', 'sphinxdoc', 'scrolls', 'agogo', 'traditional', 'nature', 'haiku', 'pyramid', 'bizstyle'}  
 [Reference](http://www.sphinx-doc.org/en/master/theming.html)  


### PR DESCRIPTION
## How to generate the documentation using sphinx

1. Go to project directory 'atarashi'
2. `export PYTHONPATH=$PYTHONPATH:${PWD}`
    - PYTHONPATH sets the search path for the importing python module.
3. Install Sphinx `pip install sphinx` (Since this project is based on python so `pip` is already installed)
4. In the project directory, `sphinx-quickstart`
    - `Root path for the documentation [.]: docs`
    - `Separate source and build directories (y/n) [n]: y`
    - `autodoc: automatically insert docstrings from modules (y/n) [n]: y`
    -  Else use the default option
5. Auto-generate the .rst files in docs/source which will be used to generate documentation 
    - `sphinx-autodoc -o docs/source atarashi/`
6. `cd docs`
7. `make html`

This will generate file in docs/build/html. Go to: index.html

You can change the theme of the documentation by changing the config.py file in docs/source folder. You can choose from {'alabaster', 'classic', 'sphinxdoc', 'scrolls', 'agogo', 'traditional', 'nature', 'haiku', 'pyramid', 'bizstyle'} 
[Reference](http://www.sphinx-doc.org/en/master/theming.html)  

----
# Updated instructions

## How to generate the documentation using sphinx

1. Go to project directory 'atarashi'.
2. Install Sphinx and m2r `pip install sphinx m2r` (Since this project is based on python so `pip` is already installed).
3. Initialise `docs/` directory with `sphinx-quickstart`

    ```bash
    mkdir docs
    cd docs/
    sphinx-quickstart
    ```
   - `Root path for the documentation [.]: .`
   - `Separate source and build directories (y/n) [n]: n`
   - `autodoc: automatically insert docstrings from modules (y/n) [n]: y`
   - `intersphinx: link between Sphinx documentation of different projects (y/n) [n]: y`
   - Else use the default option
4. Setup the `conf.py` and include `README.md`
   - Enable the following lines and change the insert path:

        ```python
        import os
        import sys
        sys.path.insert(0, os.path.abspath('../'))
        ```
   - Enable `m2r` to insert `.md` files in Sphinx documentation:

        ```python
        [...]
        extensions = [
          ...
          'm2r',
        ]
        [...]
        source_suffix = ['.rst', '.md']
        ```
   - Include `README.md` by editing `index.rst`

        ```rst
        .. toctree::
            [...]
            readme

        .. mdinclude:: ../README.md
        ```
5. Auto-generate the `.rst` files in `docs/source` which will be used to generate documentation

    ```bash
    cd docs/
    sphinx-apidoc -o source/ ../atarashi
    ```
6. `cd docs`
7. `make html`

This will generate file in `docs/_build/html`. Go to: index.html

You can change the theme of the documentation by changing `html_theme` in config.py file in `docs/` folder.
You can choose from {'alabaster', 'classic', 'sphinxdoc', 'scrolls', 'agogo', 'traditional', 'nature', 'haiku', 'pyramid', 'bizstyle'}

[Reference](http://www.sphinx-doc.org/en/master/theming.html)  
