### PR TITLE
feat(dockerization): Create docker image to run atarashi

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+/bin/
+
+# Compiled python modules.
+*.pyc
+*__pycache__*
+
+# Setuptools distribution folder.
+/dist/
+
+# Python egg metadata, regenerated from source files by setuptools.
+/*.egg-info
+/*.egg
+
+# Eclipse files
+*.project
+*.pydevproject
+*.settings*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# Atarashi Dockerfile
+# Copyright (C) 2018-2019 Gaurav Mishra, mishra.gaurav@siemens.com
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Copying and distribution of this file, with or without modification,
+#
+# Description: Docker container image recipe
+
+FROM python:3-slim
+
+LABEL maintainer="Fossology <fossology@fossology.org>"
+LABEL Description="Image for Atarashi project"
+COPY . .
+
+RUN apt-get update -q && apt-get install -q -y git gcc
+
+RUN pip install .
+
+ENTRYPOINT ["atarashi"]
+CMD ["-h"]

--- a/README.md
+++ b/README.md
@@ -82,6 +82,17 @@ Get the help by running `atarashi -h` or `atarashi --help`
     - `atarashi -a DLD -l /path/to/processedList.csv /path/to/file.c`
     - `atarashi -a Ngram -l /path/to/processedList.csv -j /path/to/ngram.json /path/to/file.c`
 
+### Running Docker image
+1. Pull Docker image
+
+    `docker pull fossology/atarashi:latest`
+2. Run the image
+
+    `docker run --rm -v <path/to/scan>:/project atarashi <options> /project/<path/to/file>`
+
+Since docker can not access host fs directly, we mount a volume from the
+directory containing the files to scan to `/project` in the container. Simply
+pass the options and path to the file relative to the mounted path.
 
 ### Test
 


### PR DESCRIPTION
### How to create docker image
* `docker build -t fossology/atarashi:latest .`

### How to run docker image
* `docker run --rm -v <path/to/scan>:/project fossology/atarashi:latest <options> /project/<path/to/file>`

>  Since docker can not access host fs directly, we mount a volume from the directory containing the files to scan to `/project` in the container. Simply pass the options and path to the file relative to the mounted path.

Merge after: #43 
Docker image: https://hub.docker.com/r/gmishx/atarashi/tags/ (`gmishx/atarashi:feat_Dockerization`)