### PR TITLE
Adds clarification regarding the need to install dependencies before building

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,12 @@ http://fossology.github.io/atarashi
 
 ### Build (optional)
 
-- `$ python setup.py build`
+- Install the dependencies:
+
+    `$ pip install -r requirements.txt`
+- Build the package using Setuptools:
+
+    `$ python setup.py build`
 - Build will generate 3 new files in your current directory
     1.  `data/Ngram_keywords.json`
     2.  `licenses/<SPDX-version>.csv`

--- a/README.md
+++ b/README.md
@@ -22,6 +22,20 @@ http://fossology.github.io/atarashi
 
 ## Steps for Installation
 
+### Installing dependencies
+
+Dependencies are required before building Atarashi. You can install them in
+following ways:
+
+- `pip install -r requirements.txt`
+
+OR
+
+- `# python setup.py install_deps`
+
+However, the dependencies are installed while installing Atarashi (running
+[install command](#install))
+
 ### Build (optional)
 
 - `$ python setup.py build`
@@ -34,11 +48,6 @@ http://fossology.github.io/atarashi
 ### Install
 
 - `# python setup.py install`
-
-### Installing just dependencies
-
-- `pip install -r requirements.txt`
-
 
 ## How to run
 

--- a/setup.py
+++ b/setup.py
@@ -84,10 +84,12 @@ class InstallAtarashiBuildRequirements(distutils.cmd.Command):
     global install_options
     global build_requirements
     global ext_links
-    if os.geteuid() != 0:
-      install_options += ['--user']
 
-    subprocess.run(install_options + build_requirements, check = True)
+    install_only_user = []
+    if os.geteuid() != 0:
+      install_only_user = ['--user']
+
+    subprocess.run(install_options + install_only_user + build_requirements, check = True)
     for package in ext_links:
       subprocess.run(install_options + ['-e', package], check = True)
 


### PR DESCRIPTION
Documentation improvement. Relates to #45.