### PR TITLE
fix(licenseDownloader): Fix build failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,15 +18,26 @@
 #
 # Description: Docker container image recipe
 
+FROM python:3 as builder
+
+WORKDIR /atarashi
+
+COPY . .
+
+RUN mkdir wheels \
+ && python -m pip wheel --use-pep517 --wheel-dir wheels .
+
 FROM python:3-slim
 
 LABEL maintainer="Fossology <fossology@fossology.org>"
 LABEL Description="Image for Atarashi project"
-COPY . .
 
-RUN apt-get update -q && apt-get install -q -y git gcc
+WORKDIR /atarashi-wheels
 
-RUN pip install .
+COPY --from=builder /atarashi/wheels/ .
+
+RUN python -m pip install *.whl \
+ && rm *.whl
 
 ENTRYPOINT ["atarashi"]
 CMD ["-h"]

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Get the help by running `atarashi -h` or `atarashi --help`
     `docker pull fossology/atarashi:latest`
 2. Run the image
 
-    `docker run --rm -v <path/to/scan>:/project atarashi <options> /project/<path/to/file>`
+    `docker run --rm -v <path/to/scan>:/project fossology/atarashi:latest <options> /project/<path/to/file>`
 
 Since docker can not access host fs directly, we mount a volume from the
 directory containing the files to scan to `/project` in the container. Simply

--- a/atarashi/license/licenseDownloader.py
+++ b/atarashi/license/licenseDownloader.py
@@ -37,17 +37,23 @@ __email__ = "amanjain5221@gmail.com"
 csvColumns = ["shortname", "fullname", "text", "license_header", "url", "deprecated", "osi_approved", "isException"]
 MAX_RETRIES = 5
 
+# Ignore warnings for insecure HTTPS connections as we are disabling
+# certification verification
+urllib3.disable_warnings(category=urllib3.exceptions.InsecureRequestWarning)
+
 def _get_http_pool():
   """
   Get the HTTP connection pool. Check if the user sets `http_proxy` environment
   variable. If the proxy is set, use proxy manager, else use default manager.
+  Ignoring the SSL verification as to avoid errors and the source is trusted.
   :return: HTTP Pool Manager
   """
   proxy_val = os.environ.get('http_proxy', False)
   if proxy_val:
-    return urllib3.ProxyManager(proxy_val)
+    return urllib3.ProxyManager(proxy_val, cert_reqs='CERT_NONE',
+                                assert_hostname=False)
   else:
-    return urllib3.PoolManager()
+    return urllib3.PoolManager(cert_reqs='CERT_NONE', assert_hostname=False)
 
 class LicenseDownloader(object):
 


### PR DESCRIPTION
### Changes
1. Ignore SSL verification to avoid connection errors.
1. Make the Docker build multi staged to reduce image size.
1. Use Python wheels to do building and installation in Docker.