### PR TITLE
style(atarashii): formatting json output

### DIFF
--- a/atarashi/atarashii.py
+++ b/atarashi/atarashii.py
@@ -138,7 +138,7 @@ def main():
   result = list(result)
   result = {"file": os.path.abspath(inputFile), "results": result}
   result = json.dumps(result, sort_keys=True, ensure_ascii=False, indent=4)
-  print("\nResult: " + result + "\n")
+  print(result + "\n")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION


 `Result:` as an extra word, in the beginning, disturbs the correct JSON architecture, which makes the output difficult to parse.

### Old Format

    Result: {
    "file": "<file-path>",
    "results": [
        {
            "description": "",
            "shortname": "OLDAP-2.6",
            "sim_score": 1,
            "sim_type": "dld"
        }
      ]  
	}

    
### New format
	
    {
    "file": "<file-path>",
    "results": [
        {
            "description": "",
            "shortname": "OLDAP-2.6",
            "sim_score": 1,
            "sim_type": "dld"
        }
      ]  
	}

   Now it follows the correct JSON Schema 

