### PR TITLE
chore(atarashi): Made changes for upload to PyPi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_install:
   - pip -V
 
 install:
+  - pip install code_comment@git+https://github.com/amanjain97/code_comment@master#egg=code_comment
   - pip install .
 
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,9 @@ WORKDIR /atarashi
 
 COPY . .
 
-RUN mkdir wheels \
- && python -m pip wheel --use-pep517 --wheel-dir wheels .
+RUN mkdir wheels
+RUN python -m pip wheel --use-pep517 --wheel-dir wheels .
+RUN python -m pip wheel --use-pep517 --wheel-dir wheels code_comment@git+https://github.com/amanjain97/code_comment@master#egg=code_comment
 
 FROM python:3.7-slim
 

--- a/README.md
+++ b/README.md
@@ -21,11 +21,20 @@ http://fossology.github.io/atarashi
 
 - Python >= v3.5
 - pip >= 18.1
+- `code_comments` (See installation bellow)
 
 ## Steps for Installation
 
 ### Install
 
+#### Install from PyPi
+- Install additional depencency code-comment
+    - `pip install code_comment@git+https://github.com/amanjain97/code_comment@master#egg=code_comment`
+- `pip install atarashi`
+
+#### Source install
+- Install additional dependency code-comment
+    - `pip install code_comment@git+https://github.com/amanjain97/code_comment@master#egg=code_comment`
 - `pip install .`
 - It will download all dependencies required and trigger build as well.
 - Build will generate 3 new files in your current directory
@@ -127,7 +136,7 @@ This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 See the GNU General Public License for more details.
- 
+
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software Foundation,
 Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
@@ -187,6 +196,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 This will generate file in `docs/_build/html`. Go to: index.html
 
-You can change the theme of the documentation by changing `html_theme` in config.py file in `docs/` folder. 
-You can choose from {'alabaster', 'classic', 'sphinxdoc', 'scrolls', 'agogo', 'traditional', 'nature', 'haiku', 'pyramid', 'bizstyle'}  
-[Reference](http://www.sphinx-doc.org/en/master/theming.html)  
+You can change the theme of the documentation by changing `html_theme` in config.py file in `docs/` folder.
+You can choose from {'alabaster', 'classic', 'sphinxdoc', 'scrolls', 'agogo', 'traditional', 'nature', 'haiku', 'pyramid', 'bizstyle'}
+[Reference](http://www.sphinx-doc.org/en/master/theming.html)

--- a/atarashi/atarashii.py
+++ b/atarashi/atarashii.py
@@ -30,7 +30,7 @@ from atarashi.agents.wordFrequencySimilarity import WordFrequencySimilarity
 
 __author__ = "Aman Jain"
 __email__ = "amanjain5221@gmail.com"
-__version__ = "0.0.9"
+__version__ = "0.0.10"
 
 
 def atarashii_runner(inputFile, processedLicense, agent_name, similarity="CosineSim", ngramJsonLoc=None, verbose=None):

--- a/setup.py
+++ b/setup.py
@@ -66,12 +66,7 @@ requirements = [
   'scipy>=0.18.1',
   'textdistance>=3.0.3',
   'pyxDamerauLevenshtein>=1.5',
-  'code_comment@git+https://github.com/amanjain97/code_comment@master#egg=code_comment',
   'urllib3>=1.24.1'
-]
-
-ext_links = [
-  'git+https://github.com/amanjain97/code_comment.git@master#egg=code_comment'
 ]
 
 class BuildAtarashiDependencies(distutils.cmd.Command):
@@ -115,17 +110,19 @@ class BuildAtarashi(setuptools.command.build_py.build_py):
 
 metadata = dict(
   name = "atarashi",
-  version = "0.0.9",
+  version = "0.0.10",
   author = "Aman Jain",
   author_email = "amanjain5221@gmail.com",
   description = ("An intelligent license scanner."),
   license = "GPL-2.0-only",
   url = "https://github.com/fossology/atarashi",
   long_description = read('README.md'),
+  long_description_content_type='text/markdown',
   classifiers = [
-    "Development Status ::  Pre-Alpha",
+    "Development Status :: 2 - Pre-Alpha",
     "Topic :: Utilities",
-    "License :: OSI Approved :: GPL v2.0 License",
+    "Intended Audience :: Legal Industry",
+    "License :: OSI Approved :: GNU General Public License v2 (GPLv2)"
   ],
   keywords = [
     "atarashi", "license", "license-scanner", "oss",
@@ -141,7 +138,6 @@ metadata = dict(
   zip_safe = False,
   setup_requires = build_requirements,
   install_requires = requirements,
-  dependency_links = ext_links,
   include_package_data = True,
   package_data = {
     'atarashi': [


### PR DESCRIPTION
## Publishing to PyPi

Published atarashi packages to PyPi: https://pypi.org/project/atarashi/

While performing the upload, following issues were faced:
1. PyPi considers external link dependencies to be unsafe and thus needs to be removed.
    - Check https://github.com/pypa/pip/issues/6301 for more
1. Had to make changes in setup.py to match the references set by PyPa.
1. Update the README to add instructions to install `code_comment` since it is removed from dependency list.
1. Bump version to 0.0.10