### PR TITLE
Fix(evaluator): Fixed evaluator commands

### DIFF
--- a/atarashi/evaluator/evaluator.py
+++ b/atarashi/evaluator/evaluator.py
@@ -52,6 +52,8 @@ def getCommand(agent_name, similarity):
       command = "atarashi -a tfidf -s CosineSim"
     elif similarity == "ScoreSim":
       command = "atarashi -a tfidf -s ScoreSim"
+    elif similarity == " ":
+      command = "atarashi -a tfidf"
     else:
       print("Please choose similarity from {CosineSim,ScoreSim}")
       return -1
@@ -63,6 +65,8 @@ def getCommand(agent_name, similarity):
       command = "atarashi -a Ngram -s DiceSim"
     elif similarity == "BigramCosineSim":
       command = "atarashi -a Ngram -s BigramCosineSim"
+    elif similarity == " ":
+      command = "atarashi -a Ngram"
     else:
       print("Please choose similarity from {CosineSim,ScoreSim}")
       return -1
@@ -119,7 +123,7 @@ if __name__ == "__main__":
   parser.add_argument("-a", "--agent_name", required=True,
                       choices=['wordFrequencySimilarity', 'DLD', 'tfidf', 'Ngram'], help="Name of the agent that you want to evaluate")
   parser.add_argument("-s", "--similarity", required=False,
-                      default="CosineSim", choices=["ScoreSim", "CosineSim", "DiceSim", "BigramCosineSim"], help="Specify the similarity algorithm that you want to evaluate"
+                      default=" ", choices=["ScoreSim", "CosineSim", "DiceSim", " ", "BigramCosineSim"], help="Specify the similarity algorithm that you want to evaluate"
                       " First 2 are for TFIDF and last 3 are for Ngram")
   args = parser.parse_args()
   agent_name = args.agent_name


### PR DESCRIPTION
# Description

The Evaluator commands are set for both two parameters i.e agent_name and similarity but some agents run without similarity type also. This needed an easy fix in the [evaluator.py](https://github.com/fossology/atarashi/blob/master/atarashi/evaluator/evaluator.py) file.

# Changes 

- The default similarity type is changed from "CosineSim" to " ".
- A simple if-else statement is written for the new condition in both the Agent types.

# Testing and verifying

You can test and verify by using the commands:
`python evaluator.py -a tfidf` For **tfidf**
`python evaluator.py -a Ngram` for **Ngram**

# Issue Ref
#61 