### PR TITLE
chore(atarashi): Bump version to 0.0.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,6 @@ COPY . .
 
 RUN mkdir wheels
 RUN python -m pip wheel --use-pep517 --wheel-dir wheels .
-RUN python -m pip wheel --use-pep517 --wheel-dir wheels code_comment@git+https://github.com/amanjain97/code_comment@master#egg=code_comment
 
 FROM python:3.7-slim
 
@@ -39,8 +38,8 @@ WORKDIR /home/atarashi
 
 COPY --from=builder /atarashi/wheels/ .
 
-RUN python -m pip install *.whl \
- && rm *.whl
+RUN python -m pip install ./*.whl \
+ && rm ./*.whl
 
 USER atarashi
 

--- a/atarashi/atarashii.py
+++ b/atarashi/atarashii.py
@@ -30,7 +30,7 @@ from atarashi.agents.wordFrequencySimilarity import WordFrequencySimilarity
 
 __author__ = "Aman Jain"
 __email__ = "amanjain5221@gmail.com"
-__version__ = "0.0.10"
+__version__ = "0.0.11"
 
 
 def atarashii_runner(inputFile, processedLicense, agent_name, similarity="CosineSim", ngramJsonLoc=None, verbose=None):

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ class BuildAtarashi(setuptools.command.build_py.build_py):
 
 metadata = dict(
   name = "atarashi",
-  version = "0.0.10",
+  version = "0.0.11",
   author = "Aman Jain",
   author_email = "amanjain5221@gmail.com",
   description = ("An intelligent license scanner."),


### PR DESCRIPTION
Bump atarashi to version 0.0.11 to push new version to PyPi with Nirjas.

Check #70 for issue.

Also, remove code_comment from Dockerfile.