### PR TITLE
feat(cd): Build packages using Github Actions

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,33 @@
+name: Publish Release Packages
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+          architecture: 'x64'
+
+      - name: Install build dependencies
+        run: python3 -m pip install --upgrade wheel --requirement requirements.txt
+
+      - name: Build packages
+        run: python3 setup.py sdist bdist_wheel
+
+      - name: Upload Packages to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.4.1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+


### PR DESCRIPTION
Use Github Actions to build packages and publish them over PyPi.
This action will be performed only when a release is tagged.

Signed-off-by: Gaurav Mishra <mishra.gaurav@siemens.com>