### PR TITLE
feat(tfidf): Speed and match improvement

### DIFF
--- a/atarashi/agents/tfidf.py
+++ b/atarashi/agents/tfidf.py
@@ -82,15 +82,15 @@ class TFIDF(AtarashiAgent):
                                     sublinear_tf=True, tokenizer=tokenize,
                                     vocabulary=processedData)
 
-    sklearn_representation = sklearn_tfidf.fit_transform(all_documents)
+    sklearn_representation = sklearn_tfidf.fit_transform(all_documents).toarray()
 
     score_arr = []
     result = 0
-    for counter, value in enumerate(sklearn_representation.toarray()[:len(sklearn_representation.toarray()) - 1],
+    for counter, value in enumerate(sklearn_representation[:len(sklearn_representation) - 1],
                                     start=0):
       sim_score = sum(value)
       score_arr.append({
-        'shortname': self.licenseList.iloc[result]['shortname'],
+        'shortname': self.licenseList.iloc[counter]['shortname'],
         'sim_type': "Sum of TF-IDF score",
         'sim_score': sim_score,
         'desc': "Score can be greater than 1 also"
@@ -115,15 +115,15 @@ class TFIDF(AtarashiAgent):
     startTime = time.time()
 
     all_documents = self.licenseList['processed_text'].tolist()
-    all_documents.append(processedData1)
-    sklearn_tfidf = TfidfVectorizer(min_df=0, use_idf=True, smooth_idf=True, sublinear_tf=True, tokenizer=tokenize)
+    sklearn_tfidf = TfidfVectorizer(min_df=0, use_idf=True, smooth_idf=True,
+                                    sublinear_tf=True, tokenizer=tokenize)
 
-    sklearn_representation = sklearn_tfidf.fit_transform(all_documents)
+    all_documents_matrix = sklearn_tfidf.fit_transform(all_documents).toarray()
+    search_martix = sklearn_tfidf.transform([processedData1]).toarray()[0]
 
-    for counter, value in enumerate(sklearn_representation.toarray()[:len(sklearn_representation.toarray()) - 1],
-                                    start=0):
-      sim_score = self.__cosine_similarity(value, sklearn_representation.toarray()[-1])
-      if sim_score >= 0.8:
+    for counter, value in enumerate(all_documents_matrix, start=0):
+      sim_score = self.__cosine_similarity(value, search_martix)
+      if sim_score >= 0.3:
         matches.append({
           'shortname': self.licenseList.iloc[counter]['shortname'],
           'sim_type': "TF-IDF Cosine Sim",

--- a/atarashi/evaluator/evaluator.py
+++ b/atarashi/evaluator/evaluator.py
@@ -29,7 +29,7 @@ from multiprocessing import Pool
 __author__ = "Ayush Bhardwaj"
 __email__ = "classicayush@gmail.com"
 
-with zipfile.ZipFile('TestFiles.zip', 'r') as zip: 
+with zipfile.ZipFile('TestFiles.zip', 'r') as zip:
   zip.extractall()
 
 # To generate colored Text
@@ -135,7 +135,7 @@ def evaluate(command):
   with Pool(os.cpu_count()) as p:
     result = list(tqdm(p.imap_unordered(processFile, fileList), total=len(fileList), unit="files"))
 
-  # success_count is the count of successfully matched files  
+  # success_count is the count of successfully matched files
   success_count = sum(result)
   accuracy = success_count * 100 / len(result)
   prCyan('Total files scanned = ' + str(len(fileList)))


### PR DESCRIPTION
The tfidf match speed is improved by getting the array only once before the loop.
The algorithm implementation was improved by removing the test data from training data.

### Comparisons
After decreasing the match threshold from 80% to 30%, the match accuracy improved from 58% to 60%. Also, sight refactoring of code improved the evaluation time from 3238 seconds to 59.02 seconds.
| | 80% | 30% |
|:---|:---:|:---:|
| Evaluator result | ![Master-tfidf-cosine](https://user-images.githubusercontent.com/18077542/103409537-5563ae00-4b8d-11eb-9184-2ab8088c8dda.png) | ![Master-tfidf-cosine-new](https://user-images.githubusercontent.com/18077542/103407536-09147000-4b85-11eb-9e3d-f7b123e9f029.png) |

Following are the changes in matching results:
```diff
36c36
< DPTC => NULL
---
> DPTC => BSD-2-Clause
58c58
< JSON => NULL
---
> JSON => MIT-feh
64c64
< LGPL-3.0+ => NULL
---
> LGPL-3.0+ => LGPL-2.1+-KDE-exception
70c70
< MIT-style => NULL
---
> MIT-style => curl
74c74
< MirOS => NULL
---
> MirOS => MirOS
91c91
< WTFPL => NULL
---
> WTFPL => WTFPL
```

After removing the test data from training data, the accuracy further increased from 60% to 62%.
![New-tfidf-cosine](https://user-images.githubusercontent.com/18077542/103407659-73c5ab80-4b85-11eb-8382-fb620a6f1aa0.png)

Following is the changes in result:
```diff
63c63
< LGPL-3.0 => NULL
---
> LGPL-3.0 => LGPL-2.1+-KDE-exception
80c80
< OpenSSL => NULL
---
> OpenSSL => openvpn-openssl-exception
82c82
< PHP-3.0 => NULL
---
> PHP-3.0 => PHP-3.0
87c87
< SGI-B-2.0 => NULL
---
> SGI-B-2.0 => SGI-B-2.0
```