### PR TITLE
feat(nirjas): Update interface with Nirjas 0.0.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,6 @@ requires = [
   "scipy>=0.18.1",
   "textdistance>=3.0.3",
   "pyxDamerauLevenshtein>=1.5",
-  "nirjas>=0.0.3",
+  "nirjas>=0.0.5",
   "urllib3>=1.24.1"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ scipy>=0.18.1
 spacy>=2.0.11
 textdistance>=3.0.3
 setuptools>=39.2.0
-nirjas>=0.0.3
+nirjas>=0.0.5
 urllib3>=1.24.1

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ build_requirements = [
   'tqdm>=4.23.4',
   'pandas>=0.23.1',
   'urllib3>=1.24.1',
-  'nirjas>=0.0.3'
+  'nirjas>=0.0.5'
 ]
 
 requirements = [
@@ -68,7 +68,7 @@ requirements = [
   'textdistance>=3.0.3',
   'pyxDamerauLevenshtein>=1.5',
   'urllib3>=1.24.1',
-  'nirjas>=0.0.3'
+  'nirjas>=0.0.5'
 ]
 
 class BuildAtarashiDependencies(distutils.cmd.Command):


### PR DESCRIPTION
1. Use the `LanguageMapper.LANG_MAP` key exposed by Nirjas to get the list of supported file extensions.
2. Import the function `extract()` as `commentExtract()` from Nirjas to eliminate confusion with function of same name in the `commentPreprocessor.py` file.
3. Update the Nirajs minimum version required to 0.0.5
4. Fix few indentations.