### PR TITLE
docs(BrokenLink): fix fuzzy string matching link

### DIFF
--- a/atarashi/agents/tfidf.py
+++ b/atarashi/agents/tfidf.py
@@ -50,7 +50,7 @@ class TFIDF(AtarashiAgent):
 
   def __cosine_similarity(self, a, b):
     '''
-    https://blog.nishtahir.com/2015/09/19/fuzzy-string-matching-using-cosine-similarity/
+    https://blog.nishtahir.com/fuzzy-string-matching-using-cosine-similarity/
 
     :return: Cosine similarity value of two word frequency arrays
     '''

--- a/atarashi/libs/utils.py
+++ b/atarashi/libs/utils.py
@@ -55,7 +55,7 @@ def ngram_l2_norm(a):
 
 def cosine_similarity(a, b):
   '''
-  https://blog.nishtahir.com/2015/09/19/fuzzy-string-matching-using-cosine-similarity/
+  https://blog.nishtahir.com/fuzzy-string-matching-using-cosine-similarity/
   Cosine similarity value of two word frequency dictionaries
   '''
   dot_product = 0


### PR DESCRIPTION
Updated the fuzzy string matching link from https://blog.nishtahir.com/2015/09/19/fuzzy-string-matching-using-cosine-similarity/ to https://blog.nishtahir.com/fuzzy-string-matching-using-cosine-similarity/