### PR TITLE
fix(dameruLevenDist): Add the missing return

### DIFF
--- a/atarashi/agents/dameruLevenDist.py
+++ b/atarashi/agents/dameruLevenDist.py
@@ -72,6 +72,7 @@ class DameruLevenDist(AtarashiAgent):
           "sim_type": "dld",
           "description": "exact match"
         })
+      return result
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In case, there is an exact match, the function `scan()` does not return anything for dameruLevenDist.