### PR TITLE
feat(evaluator): Add diff opts to run evaluator

### DIFF
--- a/atarashi/evaluator/evaluator.py
+++ b/atarashi/evaluator/evaluator.py
@@ -35,7 +35,9 @@ sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)) + '/../')
 
 from atarashii import build_scanner_obj
 
-with zipfile.ZipFile('TestFiles.zip', 'r') as zip:
+ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+CONFIG_PATH = os.path.join(ROOT_DIR, 'TestFiles.zip')
+with zipfile.ZipFile(CONFIG_PATH, 'r') as zip:
   zip.extractall()
 
 


### PR DESCRIPTION
## Description
Add an option to run [evaluator.py](https://github.com/fossology/atarashi/blob/master/atarashi/evaluator/evaluator.py) from any directory

## Changes
Currently for testing the agents accuracy user have only one option to run [evaluator.py](https://github.com/fossology/atarashi/blob/master/atarashi/evaluator/evaluator.py) i.e. user needs to go to [evaluator](https://github.com/fossology/atarashi/tree/master/atarashi/evaluator) directory then run `python evaluator.py` but after merging these changes we can run [evaluator.py](https://github.com/fossology/atarashi/blob/master/atarashi/evaluator/evaluator.py) from any directory using absolute or relative path i.e. `python /path/to/evaluator.py`

