### PR TITLE
fix: handle Nirjas extraction errors and optimize file fallback #114

### DIFF
--- a/atarashi/libs/commentPreprocessor.py
+++ b/atarashi/libs/commentPreprocessor.py
@@ -24,7 +24,8 @@ import os
 import re
 import string
 import tempfile
-
+import shutil
+import logging
 from nirjas import extract as commentExtract, LanguageMapper
 
 __author__ = "Aman Jain"
@@ -124,15 +125,20 @@ class CommentPreprocessor(object):
     with open(outputFile, 'w') as outFile:
       # if the file extension is supported
       if fileType in supportedFileExtensions:
-        data_file = commentExtract(inputFile)
-        data = licenseComment(data_file)
-        outFile.write(data)
+        try:
+          data_file = commentExtract(inputFile)
+          data = licenseComment(data_file)
+          outFile.write(data)
+        except Exception as e:
+          # if nirjas fails to parse, fallback to copying file as-is
+          logging.warning(f"Nirjas failed to extract comments from "
+                          f"{inputFile}: {e}. Falling back to raw copy.")
+          with open(inputFile) as inFile:
+            shutil.copyfileobj(inFile, outFile)
       else:
-        # if file extension is not supported
+        # if file extension is not supported, copy file as-is
         with open(inputFile) as inFile:
-          lines = inFile.read().split('\n')
-          for line in lines:
-            outFile.write(line + '\n')
+          shutil.copyfileobj(inFile, outFile)
 
     os.close(fd)
     return outputFile

--- a/atarashi/libs/commentPreprocessor.py
+++ b/atarashi/libs/commentPreprocessor.py
@@ -129,7 +129,7 @@ class CommentPreprocessor(object):
           data_file = commentExtract(inputFile)
           data = licenseComment(data_file)
           outFile.write(data)
-        except Exception as e:
+        except IndexError as e:
           # if nirjas fails to parse, fallback to copying file as-is
           logging.warning(f"Nirjas failed to extract comments from "
                           f"{inputFile}: {e}. Falling back to raw copy.")


### PR DESCRIPTION
Description
Fixes a crash in the TF-IDF agent caused by unhandled exceptions during Nirjas comment extraction, and optimizes the file fallback mechanism by replacing inefficient in-memory reads with shutil.copyfileobj().
Changes

Wrapped commentExtract() call in a try/except block inside CommentPreprocessor.extract() to gracefully handle Nirjas parsing failures instead of crashing the entire scan
Replaced inFile.read().split('\n') pattern with shutil.copyfileobj() in the exception fallback path — avoids loading the entire file into memory
Applied the same shutil.copyfileobj() optimization to the unsupported file extension fallback (else block) which had the same inefficiency
Added logging.warning() to surface extraction failures without terminating the scan
Added shutil and logging to imports

shutil uses chunk based writing thus reducing RAM overload. Impressive right?

How to test

Clone the repository and install dependencies:
(remember to install poetry with curl and not apt (gives old version).
Use this: `curl -sSL https://install.python-poetry.org | python3 -`

bash
```
git clone https://github.com/fossology/atarashi
poetry install
poetry run preprocess
cd atarashi
```

Download BusyBox (the real-world project that triggers the crash):

bash
```
wget https://sources.buildroot.net/busybox/busybox-1.36.1.tar.bz2 #use this link (updated)
tar -xf busybox-1.36.1.tar.bz2

```
Run the TF-IDF agent scan on the extracted source tree:

bash
`poetry run atarashi -a tfidf -s CosineSim ./busybox-1.36.1 `
#use poetry run and not just atarashi; atarashi is not installed in your global system path; it lives inside the Poetry virtual environment we just built.

Inferences:
The scan completes without raising IndexError: list index out of range
A WARNING log appears for any file Nirjas fails to parse
The scan continues and produces results for remaining files



Fixes #114