### PR TITLE
fix(commentPreprocessor, licenseDownloader): normalize keyword matching, SPDX URL handling, missing comma

### DIFF
--- a/atarashi/libs/commentPreprocessor.py
+++ b/atarashi/libs/commentPreprocessor.py
@@ -33,7 +33,7 @@ __email__ = "amanjain5221@gmail.com"
 args = None
 
 def licenseComment(data):
-  match_list = ['source', 'free', 'under','use',  'copyright', 'grant', 'software', 'license','licence', 'agreement', 'distribute', 'redistribution', 'liability', 'rights', 'reserved', 'general', 'public', 'modify', 'modified', 'modification', 'permission','permitted', 'granted', 'distributed', 'notice', 'distribution', 'terms', 'freely', 'licensed', 'merchantibility','redistributed', 'see', 'read', '(c)', 'copying', 'legal', 'licensing', 'spdx']
+  match_list = ['source', 'free', 'under', 'use', 'copyright', 'grant', 'software', 'license', 'licence', 'agreement', 'distribute', 'redistribution', 'liability', 'rights', 'reserved', 'general', 'public', 'modify', 'modified', 'modification', 'permission', 'permitted', 'granted', 'distributed', 'notice', 'distribution', 'terms', 'freely', 'licensed', 'merchantibility', 'merchantability', 'redistributed', 'see', 'read', '(c)', 'copying', 'legal', 'licensing', 'spdx']
 
   MLmapCount, CSLmapCount, SLmapCount = [], [], []
   comment = ""

--- a/atarashi/libs/commentPreprocessor.py
+++ b/atarashi/libs/commentPreprocessor.py
@@ -33,7 +33,7 @@ __email__ = "amanjain5221@gmail.com"
 args = None
 
 def licenseComment(data):
-  match_list = ['source', 'free', 'under','use',  'copyright', 'grant', 'software', 'license','licence', 'agreement', 'distribute', 'redistribution', 'liability', 'rights', 'reserved', 'general', 'public', 'modify', 'modified', 'modification', 'permission','permitted' 'granted', 'distributed', 'notice', 'distribution', 'terms', 'freely', 'licensed', 'merchantibility','redistributed', 'see', 'read', '(c)', 'copying', 'legal', 'licensing', 'spdx']
+  match_list = ['source', 'free', 'under','use',  'copyright', 'grant', 'software', 'license','licence', 'agreement', 'distribute', 'redistribution', 'liability', 'rights', 'reserved', 'general', 'public', 'modify', 'modified', 'modification', 'permission','permitted', 'granted', 'distributed', 'notice', 'distribution', 'terms', 'freely', 'licensed', 'merchantibility','redistributed', 'see', 'read', '(c)', 'copying', 'legal', 'licensing', 'spdx']
 
   MLmapCount, CSLmapCount, SLmapCount = [], [], []
   comment = ""

--- a/atarashi/license/licenseDownloader.py
+++ b/atarashi/license/licenseDownloader.py
@@ -91,7 +91,7 @@ class LicenseDownloader(object):
     licenses = jsonData.get('licenses')
 
     version = jsonData.get('licenseListVersion').replace(".", "_")
-    releaseDate = jsonData.get('releaseDate')
+    releaseDate = jsonData.get('releaseDate').replace(':','-').replace('T','_').replace('Z','')
     if licenses is not None:
       fileName = releaseDate + '_' + version + '.csv'
       directory = os.path.dirname(os.path.abspath(__file__))
@@ -140,12 +140,12 @@ class LicenseDownloader(object):
     nextUrl = "https://spdx.org/licenses/{0}.json".format(licenseDict['shortname'])
     licenseData = LicenseDownloader._download_json(nextUrl)
     licenseDict['text'] = licenseData.get('licenseText')
-    licenseDict['url'] = licenseData.get('seeAlso')
+    licenseDict['url'] = ', '.join(licenseData.get('seeAlso', [])) if isinstance(licenseData.get('seeAlso'), list) else licenseData.get('seeAlso', '')
     licenseDict['license_header'] = licenseData.get('standardLicenseHeader', '')
     if 'There is no standard license header for the license' in licenseDict['license_header']:
       licenseDict['license_header'] = ''
 
-    return pd.DataFrame(licenseDict, columns=csvColumns)
+    return pd.DataFrame([licenseDict], columns=csvColumns)
 
   @staticmethod
   def fetch_exceptional_license(license):
@@ -161,11 +161,11 @@ class LicenseDownloader(object):
     nextUrl = "https://spdx.org/licenses/{0}.json".format(licenseDict['shortname'])
     licenseData = LicenseDownloader._download_json(nextUrl)
     licenseDict['text'] = licenseData.get('licenseExceptionText')
-    licenseDict['url'] = licenseData.get('seeAlso')
+    licenseDict['url'] = ', '.join(licenseData.get('seeAlso', [])) if isinstance(licenseData.get('seeAlso'), list) else licenseData.get('seeAlso', '')
     licenseDict['license_header'] = licenseData.get('standardLicenseHeader', '')
     if 'There is no standard license header for the license' in licenseDict['license_header']:
       licenseDict['license_header'] = ''
-    return pd.DataFrame(licenseDict, columns=csvColumns)
+    return pd.DataFrame([licenseDict], columns=csvColumns)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Small bug fixes in comment extraction and SPDX download normalization.

### Changes

Updated keyword normalization in commentPreprocessor.py by cleaning list formatting (added a missing comma) and added "merchantability" keyword support ("merchantibility" exists, but "merchantability" is the common spelling).
Normalized seeAlso handling in licenseDownloader.py so that the url is stored consistently as a string.
One-row DataFrame creation per license/exception entry using [licenseDict].
Made SPDX filename generation Windows-safe by sanitizing the releaseDate before building CSV filename in licenseDownloader.py.

## How to test

```
poetry install
poetry run preprocess
```
Create a new test file ex: `dummy_license_file.txt`

`poetry run atarashi -a DLD .\dummy_license_file.txt`

## Validation:
Output from tests:
<img width="903" height="156" alt="image" src="https://github.com/user-attachments/assets/b03b8ba0-0c28-4608-b668-3049375ed0ec" />
<img width="872" height="252" alt="image" src="https://github.com/user-attachments/assets/65bbb09a-f614-4894-8cbf-12a51bc95576" />
